### PR TITLE
nicer format when coin name is present

### DIFF
--- a/coin_checker.py
+++ b/coin_checker.py
@@ -73,7 +73,7 @@ class CoinChecker:
             for pair in pairs
         )
         if coin_name:
-            ticker_url = f'{ticker_url} ({coin_name})'
+            return f'*{coin_name}* listed on {api.md_link}\n{ticker_url}'
         return f'{ticker_url} listed on {api.md_link}'
 
     @staticmethod

--- a/exchange/radarrelay.py
+++ b/exchange/radarrelay.py
@@ -17,7 +17,7 @@ class RadarRelayApi(BaseApi):
 
     @property
     def md_link(self):
-        return self.markdown_url('Radar relay', 'https://app.radarrelay.com')
+        return self.markdown_url('Radar Relay', 'https://app.radarrelay.com')
 
     async def tradable_pairs(self) -> set:
         response = await self.get(


### PR DESCRIPTION
Change
> SCM/BTC, SCM/ETH (ScamCoin) listed on Bittrex

To:
> **ScamCoin** listed on Bittrex
> SCM/BTC, SCM/ETH

This should look nicer in notifications/previews.